### PR TITLE
[github-actions] add `build` workflow for EFR32 sample apps and a pretty check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,120 @@
+#
+#  Copyright (c) 2022, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+name: Build
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    branches:
+      - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'SiliconLabs/KNX-IOT-STACK' && github.run_id) || github.ref }}
+  cancel-in-progress: true
+
+env:
+  TOOLCHAIN_DIR: ${{ github.workspace }}/.toolchain
+
+jobs:
+  arm-gcc:
+    name: Arm GNU Toolchain ${{ matrix.gcc_ver }}
+    runs-on: ubuntu-22.04
+    container:
+      image: siliconlabsinc/ot-efr32-dev:latest
+      options: --user 1001
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - gcc_ver: 12.2.Rel1
+            gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz
+            gcc_extract_dir: arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi
+          - gcc_ver: 12.3.Rel1
+            gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz
+            gcc_extract_dir: arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ matrix.gcc_ver }}
+          verbose: 2
+
+      - name: Restore ARM Toolchain
+        uses: actions/cache@v4
+        id: cache-arm-toolchain
+        with:
+          path: ${{ env.TOOLCHAIN_DIR }}/${{ matrix.gcc_extract_dir }}
+          key: ${{ matrix.gcc_extract_dir }}
+
+      - name: Bootstrap ARM Toolchain
+        run: script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }} ${{ env.TOOLCHAIN_DIR }}
+
+
+      - name: Create LFS file hash list
+        run: git -C deps/ot-efr32/third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore gecko_sdk LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache-gecko_sdk
+        with:
+            path: .git/modules/deps/ot-efr32/modules/third_party/silabs/gecko_sdk/lfs
+            key: lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: git -C deps/ot-efr32/third_party/silabs/gecko_sdk lfs pull
+
+      - name: Build
+        run: |
+          export PATH=${{ env.TOOLCHAIN_DIR }}/${{ matrix.gcc_extract_dir }}/bin:$PATH
+          script/build brd4187c
+
+      - name: Gather SLC generated files
+        if: failure()
+        run: |
+          rm -rf artifact && mkdir artifact
+          for b in build/*/slc; do
+              board=$(basename $(dirname "${b}"))
+
+              echo "Artifacting '${board}'"
+              mkdir -p "artifact/${board}"
+              mv "build/${board}/slc" "artifact/${board}"
+          done
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: build-${{ matrix.gcc_ver }}
+          path: artifact

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,70 @@
+#
+#  Copyright (c) 2022, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+name: Checks
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    branches:
+      - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-efr32' && github.run_id) || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  pretty:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+
+    # The pretty script uses the .clang-format from the ot-efr32 submodule
+    - name: Clone ot-efr32 submodule
+      run: git submodule update --init --depth 1 deps/ot-efr32
+
+    - name: Bootstrap
+      run: |
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        sudo apt-get --no-install-recommends install -y clang-format-14 shellcheck
+        python3 -m pip install yapf==0.29.0
+        sudo snap install shfmt
+    - name: Check
+      run: |
+        script/make-pretty check
+
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-verbose-mode: 'yes'

--- a/script/build
+++ b/script/build
@@ -42,7 +42,6 @@ gsdk_dir="${ot_efr32_repo_dir}/third_party/silabs/gecko_sdk"
 echo "REPO DIR ${repo_dir}"
 echo "OT EFR32 REPO DIR ${ot_efr32_repo_dir}"
 
-
 # shellcheck source=script/efr32-definitions
 source "${ot_efr32_repo_dir}/script/efr32-definitions"
 
@@ -157,7 +156,7 @@ build_knx()
         -DOT_PLATFORM_LIB=openthread-efr32-knx \
         -DOT_PLATFORM_LIB_DIR="${slc_generated_projects_dir}/knx" \
         -DCMAKE_TOOLCHAIN_FILE=deps/ot-efr32/src/"${platform}"/arm-none-eabi.cmake \
-        "$@" "${repo_dir}" \
+        "$@" "${repo_dir}"
 
     # Build the apps
     ninja "${OT_CMAKE_NINJA_TARGET[@]}"
@@ -208,7 +207,7 @@ main()
         OT_CMAKE_NINJA_TARGET=(
             "ot-lightswitch-actuator"
             "ot-lightswitch-sensor"
-            )
+        )
     fi
 
     # Build the KNX apps

--- a/script/make-pretty
+++ b/script/make-pretty
@@ -71,7 +71,6 @@ fi
 script_dir="$(realpath "$(dirname "${script_path}")")"
 repo_dir="$(dirname "${script_dir}")"
 
-OT_BUILD_JOBS=$(getconf _NPROCESSORS_ONLN)
 readonly OT_BUILD_JOBS
 
 OT_EXCLUDE_DIRS=(
@@ -104,21 +103,43 @@ readonly OT_MARKDOWN_SOURCES
 OT_PYTHON_SOURCES=('*.py')
 readonly OT_PYTHON_SOURCES
 
-OT_SCRIPT_DIR="${repo_dir}"/deps/ot-efr32/openthread/script
-readonly OT_SCRIPT_DIR
-
 CLANG_FORMAT_STYLE_FILE="${repo_dir}/deps/ot-efr32/.clang-format"
 export CLANG_FORMAT_STYLE_FILE
+
+get_files_to_format()
+{
+    local file_patterns
+    file_patterns=("$@")
+    local files_to_format
+
+    local git_ls_files
+    git_ls_files=$(git ls-files "${file_patterns[@]}")
+    for file in $(echo "${git_ls_files}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))"); do
+        files_to_format+=("${file}")
+    done
+
+    echo "${files_to_format[@]}"
+}
 
 do_clang_format()
 {
     echo -e '========================================'
     echo -e '     format c/c++ (clang-format)'
     echo -e '========================================'
-
     pushd "${repo_dir}"
-    git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -t -n1 -P"$OT_BUILD_JOBS" "${repo_dir}"/script/clang-format -style=file:"${CLANG_FORMAT_STYLE_FILE}" -i -verbose
+
+    local files_to_format
+    files_to_format=($(get_files_to_format "${OT_CLANG_SOURCES[@]}"))
+
+    if [ ${#files_to_format[@]} -eq 0 ]; then
+        echo "No clang files to format."
+        return
+    fi
+
+    (
+        set -x
+        "${repo_dir}"/script/clang-format -style=file:"${CLANG_FORMAT_STYLE_FILE}" -i -verbose "${files_to_format[@]}"
+    )
     popd
 }
 
@@ -127,10 +148,20 @@ do_clang_format_check()
     echo -e '========================================'
     echo -e '     check c/c++ (clang-format)'
     echo -e '========================================'
-
     pushd "${repo_dir}"
-    git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -n1 -P"$OT_BUILD_JOBS" "${repo_dir}"/script/clang-format-check
+
+    local files_to_format
+    files_to_format=($(get_files_to_format "${OT_CLANG_SOURCES[@]}"))
+
+    if [ ${#files_to_format[@]} -eq 0 ]; then
+        echo "No clang files to check."
+        return
+    fi
+
+    (
+        set -x
+        "${repo_dir}"/script/clang-format-check "${files_to_format[@]}"
+    )
     popd
 }
 
@@ -139,10 +170,20 @@ do_markdown_format()
     echo -e '========================================'
     echo -e '     format markdown'
     echo -e '========================================'
-
     pushd "${repo_dir}"
-    git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs npx prettier@2.0.4 --write
+
+    local files_to_format
+    files_to_format=($(get_files_to_format "${OT_MARKDOWN_SOURCES[@]}"))
+
+    if [ ${#files_to_format[@]} -eq 0 ]; then
+        echo "No markdown files to format."
+        return
+    fi
+
+    (
+        set -x
+        npx prettier@2.0.4 --write "${files_to_format[@]}"
+    )
     popd
 }
 
@@ -151,10 +192,20 @@ do_markdown_check()
     echo -e '========================================'
     echo -e '     check markdown'
     echo -e '========================================'
-
     pushd "${repo_dir}"
-    git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs npx prettier@2.0.4 --check
+
+    local files_to_format
+    files_to_format=($(get_files_to_format "${OT_MARKDOWN_SOURCES[@]}"))
+
+    if [ ${#files_to_format[@]} -eq 0 ]; then
+        echo "No markdown files to check."
+        return
+    fi
+
+    (
+        set -x
+        npx prettier@2.0.4 --check "${files_to_format[@]}"
+    )
     popd
 }
 
@@ -163,10 +214,20 @@ do_python_format()
     echo -e '========================================'
     echo -e '     format python'
     echo -e '========================================'
-
     pushd "${repo_dir}"
-    git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -n10 -P"$OT_BUILD_JOBS" python3 -m yapf --verbose --style '{based_on_style: google, column_limit: 119}' -ipr
+
+    local files_to_format
+    files_to_format=($(get_files_to_format "${OT_PYTHON_SOURCES[@]}"))
+
+    if [ ${#files_to_format[@]} -eq 0 ]; then
+        echo "No python files to format."
+        return
+    fi
+
+    (
+        set -x
+        python3 -m yapf --verbose --style '{based_on_style: google, column_limit: 119}' -ipr "${files_to_format[@]}"
+    )
     popd
 }
 
@@ -175,10 +236,20 @@ do_python_check()
     echo -e '========================================'
     echo -e '     check python'
     echo -e '========================================'
-
     pushd "${repo_dir}"
-    git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -n10 -P"$OT_BUILD_JOBS" python3 -m yapf --verbose --style '{based_on_style: google, column_limit: 119}' -dpr
+
+    local files_to_format
+    files_to_format=($(get_files_to_format "${OT_PYTHON_SOURCES[@]}"))
+
+    if [ ${#files_to_format[@]} -eq 0 ]; then
+        echo "No python files to check."
+        return
+    fi
+
+    (
+        set -x
+        python3 -m yapf --verbose --style '{based_on_style: google, column_limit: 119}' -dpr "${files_to_format[@]}"
+    )
     popd
 }
 
@@ -187,10 +258,20 @@ do_shell_format()
     echo -e '========================================'
     echo -e '     format shell'
     echo -e '========================================'
-
     pushd "${repo_dir}"
-    git ls-files | xargs shfmt -f | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -n1 -P"$OT_BUILD_JOBS" shfmt -i 4 -bn -ci -fn -s -w
+
+    local files_to_format
+    files_to_format=($(git ls-files | xargs shfmt -f | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))"))
+
+    if [ ${#files_to_format[@]} -eq 0 ]; then
+        echo "No shell files to format."
+        return
+    fi
+
+    (
+        set -x
+        shfmt -i 4 -bn -ci -fn -s -w "${files_to_format[@]}"
+    )
     popd
 }
 
@@ -199,12 +280,21 @@ do_shell_check()
     echo -e '========================================'
     echo -e '     check shell'
     echo -e '========================================'
-
     pushd "${repo_dir}"
-    local files
-    files=$(git ls-files | xargs shfmt -f | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))")
-    printf '%s\n' "${files[@]}" | xargs -t -n1 -P"$OT_BUILD_JOBS" shfmt -i 4 -bn -ci -fn -s -d
-    printf '%s\n' "${files[@]}" | xargs -t -n1 -P"$OT_BUILD_JOBS" shellcheck -x --source-path="${repo_dir}"
+
+    local files_to_format
+    files_to_format=($(git ls-files | xargs shfmt -f | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))"))
+
+    if [ ${#files_to_format[@]} -eq 0 ]; then
+        echo "No shell files to check."
+        return
+    fi
+
+    (
+        set -x
+        shfmt -i 4 -bn -ci -fn -s -d "${files_to_format}"
+        shellcheck -x --source-path="${repo_dir}" "${files_to_format}"
+    )
     popd
 }
 


### PR DESCRIPTION
This copies the `Build` and `Pretty` checks from `ot-efr32`.

Also adds some script improvements for `script/make-pretty` which fix a bug where the check fails if no files are supplied for a check.

Ignore the two failing checks `CLA Assistant` and `GitlabSync / Git Repo Sync`. Those are existing checks which are meant to run on the upstream repo.