### PR TITLE
[script] move slc generation dir to `KNX-IOT-STACK/build/$board/slc`

### DIFF
--- a/script/build
+++ b/script/build
@@ -132,6 +132,7 @@ generate()
     echo "Generate openthread-efr32-knx and openthread-efr32-knx-mbedtls libs"
     echo "========================================================================================================="
     set -x
+    export OT_CMAKE_BUILD_DIR=${board_build_dir?}
     "${ot_efr32_repo_dir}/script/generate" \
         "${repo_dir}/port/ot-efr32/openthread-efr32-knx.slcp" \
         "${slc_generated_projects_dir}/knx" \


### PR DESCRIPTION
This moves the slc generation dir into `build/$board/slc`.

**Example**: https://github.com/SiliconLabs/KNX-IOT-STACK/actions/runs/10274151298/job/28430229125?pr=7#step:10:153